### PR TITLE
Vertex forwarder for transparent forwarding of /vertex route + Authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ This project provides a proxy server that translates OpenAI API requests to Goog
 
 The proxy handles:
 - Authentication with Google Cloud using Application Default Credentials (ADC).
+- Client authentication using API keys.
 - Caching of authentication tokens.
 - Serving a static list of available Vertex AI models under the `/v1/models` endpoint.
 - Proxying chat completion requests to the appropriate Vertex AI endpoint.
+- Direct Vertex AI API access via the `/vertex/*` route.
 
 It is designed to be run as a Docker container, typically orchestrated with `docker-compose` alongside an application like Open WebUI.
 
@@ -21,6 +23,7 @@ It is designed to be run as a Docker container, typically orchestrated with `doc
 3.  **Environment Variables**:
     *   `VERTEXAI_PROJECT`: Your Google Cloud Project ID.
     *   `VERTEXAI_LOCATION`: The Google Cloud region for Vertex AI (e.g., `us-central1`).
+    *   `API_KEY`: A secret key required for client authentication.
 4.  **Docker and Docker Compose**: Required to build and run the service.
 
 ## How to Run
@@ -33,6 +36,7 @@ The project includes a `docker-compose.yml` file for easy setup with Open WebUI.
     ```
     VERTEXAI_PROJECT=your-gcp-project-id
     VERTEXAI_LOCATION=us-central1
+    API_KEY=your-secret-api-key
     ```
 
 2.  **Verify ADC Path (if necessary)**:
@@ -68,6 +72,25 @@ The Go application includes unit tests.
     go test ./...
     ```
 
+### Manual Testing
+
+You can test the proxy manually using curl:
+
+1.  **Test authentication (should return 401)**:
+    ```bash
+    curl -v http://localhost:8080/v1/models
+    ```
+
+2.  **Test with valid API key**:
+    ```bash
+    curl -v -H "Authorization: Bearer your-secret-api-key" http://localhost:8080/v1/models
+    ```
+
+3.  **Test Vertex AI direct access**:
+    ```bash
+    curl -v -H "Authorization: Bearer your-secret-api-key" http://localhost:8080/vertex/v1/projects/PROJECT_ID/locations/LOCATION/publishers/google/models/gemini-pro:generateContent
+    ```
+
 ## Configuration
 
 ### Proxy Service (`main.go`)
@@ -76,6 +99,7 @@ The proxy service is configured via environment variables:
 
 *   `VERTEXAI_PROJECT`: (Required) Your Google Cloud Project ID.
 *   `VERTEXAI_LOCATION`: (Required) The Google Cloud region for Vertex AI (e.g., `us-central1`) or `global` for the global endpoint.
+*   `API_KEY`: (Required) Secret key for client authentication. Clients must include `Authorization: Bearer <API_KEY>` in request headers.
 *   `GOOGLE_APPLICATION_CREDENTIALS`: (Set within `docker-compose.yml`) Points to the path of the mounted ADC JSON file inside the container (e.g., `/app/gcp_adc.json`).
 *   `VERTEXAI_AVAILABLE_MODELS`: (Optional) A comma-separated list of model IDs to serve via the `/v1/models` endpoint.
     *   Example: `VERTEXAI_AVAILABLE_MODELS="google/gemini-1.0-pro,google/gemini-1.5-flash-preview-0514"`
@@ -176,5 +200,5 @@ LOG_FORMAT=json
     *   Ensure your ADC file is correctly mounted and `GOOGLE_APPLICATION_CREDENTIALS` inside the container points to it.
     *   Verify the Vertex AI API is enabled in your GCP project.
     *   Check that the service account associated with your ADC (or your user credentials) has the "Vertex AI User" role or equivalent permissions.
-*   **"dummy_key_for_vertex_proxy"**: This key is used by Open WebUI to satisfy its requirement for an API key. The actual authentication to Vertex AI is handled by the proxy using Google Cloud ADC.
+*   **API Key Authentication**: All requests to the proxy must include an `Authorization: Bearer <API_KEY>` header. The key must match the `API_KEY` environment variable. The proxy then handles authentication to Vertex AI using Google Cloud ADC.
 *   **Model Not Found**: Ensure the model name used in your client application (e.g., Open WebUI) matches one of the models supported by the proxy (e.g., `google/gemini-2.5-pro-preview-03-25`). The client must send the model name with the `google/` prefix if required by the Vertex AI backend, as the proxy no longer automatically prepends it.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+go build -o vertexai-proxy main.go

--- a/main.go
+++ b/main.go
@@ -305,7 +305,7 @@ func makeVertexProxy(target *url.URL) *httputil.ReverseProxy {
 			// Replace project and location in the path with environment variable values
 			// Expected format: /v1/projects/{project}/locations/{location}/...
 			pathParts := strings.Split(strings.TrimPrefix(strippedPath, "/"), "/")
-			if len(pathParts) >= 5 && pathParts[0] == "v1" && pathParts[1] == "projects" && pathParts[3] == "locations" {
+			if len(pathParts) >= 5 && pathParts[1] == "projects" && pathParts[3] == "locations" {
 				// Override project and location with environment variable values
 				pathParts[2] = projectID
 				pathParts[4] = location

--- a/main.go
+++ b/main.go
@@ -266,6 +266,76 @@ func makeProxy(target *url.URL) *httputil.ReverseProxy {
 	}
 }
 
+func makeVertexProxy(target *url.URL) *httputil.ReverseProxy {
+	return &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			logger.Debug("makeVertexProxy Director: Processing request", "method", req.Method, "path", req.URL.Path, "remote_addr", req.RemoteAddr)
+
+			req.URL.Scheme = target.Scheme
+			req.URL.Host = target.Host
+			req.Host = target.Host
+
+			originalPath := req.URL.Path
+			req.URL.Path = strings.TrimPrefix(originalPath, "/vertex")
+
+			logger.Debug("makeVertexProxy Director: Rewriting path", "original_path", originalPath, "new_path", req.URL.Path)
+			logger.Debug("makeVertexProxy Director: Final target URL for upstream", "url", req.URL.String())
+
+			if tok, err := getToken(req.Context()); err == nil {
+				req.Header.Set("Authorization", "Bearer "+tok)
+				logger.Debug("makeVertexProxy Director: Authorization header set", "path", req.URL.Path)
+			} else {
+				logger.Error("Error getting token for request", "path", originalPath, "error", err)
+			}
+		},
+		ModifyResponse: func(resp *http.Response) error {
+			logger.Debug("makeVertexProxy ModifyResponse: Received response from upstream", "host", resp.Request.URL.Host, "method", resp.Request.Method, "path", resp.Request.URL.Path, "status", resp.Status)
+			var upstreamHeaders strings.Builder
+			for k, v := range resp.Header {
+				upstreamHeaders.WriteString(fmt.Sprintf("\n  %s: %s", k, strings.Join(v, ", ")))
+			}
+			if upstreamHeaders.Len() > 0 {
+				logger.Debug("makeVertexProxy ModifyResponse: Upstream response headers", "headers", upstreamHeaders.String())
+			}
+
+			if resp.StatusCode >= 400 {
+				bodyBytes, err := io.ReadAll(resp.Body)
+				if err != nil {
+					logger.Error("makeVertexProxy ModifyResponse: Error reading error response body from upstream", "error", err)
+					resp.Body = io.NopCloser(bytes.NewBuffer(nil))
+				} else {
+					resp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+					if resp.Header.Get("Content-Encoding") == "gzip" {
+						gzipReader, err := gzip.NewReader(bytes.NewReader(bodyBytes))
+						if err != nil {
+							logger.Error("makeVertexProxy ModifyResponse: Error creating gzip reader for error response body", "error", err, "detail", "Logging raw body.")
+							logger.Debug("makeVertexProxy ModifyResponse: Upstream error response body (raw gzipped)", "body", string(bodyBytes))
+						} else {
+							decompressedBodyBytes, err := io.ReadAll(gzipReader)
+							if err != nil {
+								logger.Error("makeVertexProxy ModifyResponse: Error decompressing gzip error response body", "error", err, "detail", "Logging raw body.")
+								logger.Debug("makeVertexProxy ModifyResponse: Upstream error response body (raw gzipped)", "body", string(bodyBytes))
+							} else {
+								logger.Debug("makeVertexProxy ModifyResponse: Upstream error response body (decompressed)", "body", string(decompressedBodyBytes))
+							}
+							gzipReader.Close()
+						}
+					} else {
+						logger.Debug("makeVertexProxy ModifyResponse: Upstream error response body", "body", string(bodyBytes))
+					}
+				}
+			}
+			return nil
+		},
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			logger.Error("HTTP proxy error", "method", r.Method, "target_url", r.URL.String(), "error", err)
+			w.WriteHeader(http.StatusBadGateway)
+			io.WriteString(w, fmt.Sprintf("Proxy error connecting to upstream service: %v", err))
+		},
+	}
+}
+
 func handleModels(w http.ResponseWriter, r *http.Request) {
 	logger.Debug("handleModels: Received request", "method", r.Method, "path", r.URL.Path, "remote_addr", r.RemoteAddr)
 
@@ -356,7 +426,21 @@ func main() {
 	}
 	logger.Info("main: Proxy target URL configured", "url", target.String())
 
+	var vertexProxyHost string
+	if location == "global" {
+		vertexProxyHost = "aiplatform.googleapis.com"
+	} else {
+		vertexProxyHost = fmt.Sprintf(vertexAIAPIHostFormat, location)
+	}
+
+	vertexTarget, err := url.Parse("https://" + vertexProxyHost)
+	if err != nil {
+		log.Fatalf("main: Error parsing vertex target host '%s': %v", vertexProxyHost, err)
+	}
+	logger.Info("main: Vertex proxy target URL configured", "url", vertexTarget.String())
+
 	http.HandleFunc("/v1/models", handleModels)
+	http.Handle("/vertex/", makeVertexProxy(vertexTarget))
 	http.Handle("/v1/", makeProxy(target))
 
 	// Get port from environment variable, default to 8080

--- a/main.go
+++ b/main.go
@@ -394,12 +394,12 @@ func handleModels(w http.ResponseWriter, r *http.Request) {
 
 		if len(customModelIDsFiltered) > 0 {
 			modelIDs = customModelIDsFiltered
-			logger.Info("handleModels: Using custom models from VERTEXAI_AVAILABLE_MODELS", "models", modelIDs)
+			logger.Debug("handleModels: Using custom models from VERTEXAI_AVAILABLE_MODELS", "models", modelIDs)
 		} else {
 			logger.Warn("handleModels: VERTEXAI_AVAILABLE_MODELS set but empty", "env_var_value", availableModelsStr, "using_default_models", modelIDs)
 		}
 	} else {
-		logger.Info("handleModels: VERTEXAI_AVAILABLE_MODELS not set or empty", "using_default_models", modelIDs)
+		logger.Debug("handleModels: VERTEXAI_AVAILABLE_MODELS not set or empty", "using_default_models", modelIDs)
 	}
 
 	currentTime := time.Now().Unix()
@@ -424,7 +424,7 @@ func handleModels(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
 		return
 	}
-	logger.Info("handleModels: Successfully sent models list", "count", len(responseModels))
+	logger.Debug("handleModels: Successfully sent models list", "count", len(responseModels))
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -89,6 +89,7 @@ var googleFindDefaultCredentials = google.FindDefaultCredentials
 var (
 	projectID string
 	location  string
+	apiKey    string
 	// vertexAIAPIHostFormat specifies the format for the Vertex AI API host.
 	// It's a variable to allow overriding for testing.
 	// Example: "%s-aiplatform.googleapis.com" where %s is the location.
@@ -143,6 +144,29 @@ func getToken(ctx context.Context) (string, error) {
 	expiry = tok.Expiry
 	logger.Info("getToken: Successfully fetched new token.")
 	return token, nil
+}
+
+func authenticateRequest(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+		if authHeader == "" {
+			logger.Warn("authenticateRequest: Missing Authorization header", "path", r.URL.Path, "remote_addr", r.RemoteAddr)
+			w.WriteHeader(http.StatusUnauthorized)
+			io.WriteString(w, "Authorization header required")
+			return
+		}
+
+		expectedAuth := "Bearer " + apiKey
+		if authHeader != expectedAuth {
+			logger.Warn("authenticateRequest: Invalid API key", "path", r.URL.Path, "remote_addr", r.RemoteAddr)
+			w.WriteHeader(http.StatusUnauthorized)
+			io.WriteString(w, "Invalid API key")
+			return
+		}
+
+		logger.Debug("authenticateRequest: Authentication successful", "path", r.URL.Path, "remote_addr", r.RemoteAddr)
+		next.ServeHTTP(w, r)
+	})
 }
 
 func makeProxy(target *url.URL) *httputil.ReverseProxy {
@@ -397,11 +421,16 @@ func main() {
 	logger.Info("Starting proxy server...")
 	location = os.Getenv("VERTEXAI_LOCATION")
 	projectID = os.Getenv("VERTEXAI_PROJECT")
+	apiKey = os.Getenv("API_KEY")
 
 	logger.Info("main: Configuration", "vertexai_location", location, "vertexai_project", projectID)
 
 	if location == "" || projectID == "" {
 		log.Fatal("VERTEXAI_LOCATION and VERTEXAI_PROJECT env vars must be set")
+	}
+
+	if apiKey == "" {
+		log.Fatal("API_KEY env var must be set")
 	}
 
 	var baseURL string
@@ -439,9 +468,9 @@ func main() {
 	}
 	logger.Info("main: Vertex proxy target URL configured", "url", vertexTarget.String())
 
-	http.HandleFunc("/v1/models", handleModels)
-	http.Handle("/vertex/", makeVertexProxy(vertexTarget))
-	http.Handle("/v1/", makeProxy(target))
+	http.Handle("/v1/models", authenticateRequest(http.HandlerFunc(handleModels)))
+	http.Handle("/vertex/", authenticateRequest(makeVertexProxy(vertexTarget)))
+	http.Handle("/v1/", authenticateRequest(makeProxy(target)))
 
 	// Get port from environment variable, default to 8080
 	port := os.Getenv("PORT")

--- a/main.go
+++ b/main.go
@@ -300,9 +300,21 @@ func makeVertexProxy(target *url.URL) *httputil.ReverseProxy {
 			req.Host = target.Host
 
 			originalPath := req.URL.Path
-			req.URL.Path = strings.TrimPrefix(originalPath, "/vertex")
+			strippedPath := strings.TrimPrefix(originalPath, "/vertex")
 
-			logger.Debug("makeVertexProxy Director: Rewriting path", "original_path", originalPath, "new_path", req.URL.Path)
+			// Replace project and location in the path with environment variable values
+			// Expected format: /v1/projects/{project}/locations/{location}/...
+			pathParts := strings.Split(strings.TrimPrefix(strippedPath, "/"), "/")
+			if len(pathParts) >= 5 && pathParts[0] == "v1" && pathParts[1] == "projects" && pathParts[3] == "locations" {
+				// Override project and location with environment variable values
+				pathParts[2] = projectID
+				pathParts[4] = location
+				req.URL.Path = "/" + strings.Join(pathParts, "/")
+				logger.Debug("makeVertexProxy Director: Overrode project and location", "original_path", originalPath, "stripped_path", strippedPath, "final_path", req.URL.Path, "project", projectID, "location", location)
+			} else {
+				req.URL.Path = strippedPath
+				logger.Debug("makeVertexProxy Director: Path doesn't match expected format, using as-is", "original_path", originalPath, "final_path", req.URL.Path)
+			}
 			logger.Debug("makeVertexProxy Director: Final target URL for upstream", "url", req.URL.String())
 
 			if tok, err := getToken(req.Context()); err == nil {

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+export VERTEXAI_PROJECT=vertexai-469323
+export VERTEXAI_LOCATION=us-east5
+export VERTEXAI_AVAILABLE_MODELS="google/gemini-2.5-pro,google/gemini-2.5-flash"
+export PORT=6002
+
+./vertexai-proxy


### PR DESCRIPTION
Not sure, you'll ever need this, but if you do, it's available now.

  1. API key authentication - All routes now require Authorization: Bearer <API_KEY>
  2. /vertex route - Direct access to Vertex AI API (with replacement of project + location)
  3. Updated README - Documentation for the new features

Can be used with e.g. claude code to forward with a different key.